### PR TITLE
Restore poster-no-qr rationale and TinyMCE scroll gotcha (stack on #76)

### DIFF
--- a/.claude/skills/huodongxing-create-event/SKILL.md
+++ b/.claude/skills/huodongxing-create-event/SKILL.md
@@ -142,7 +142,9 @@ agent-browser --session hdx eval 'var html = "<h2>...</h2><p>...</p>"; document.
 
 **Use literal Unicode characters** (`·`, `–`, `—`, `'`, `"`) in HTML, not entity references — UEditor on the edit page double-escapes `&middot;` → `&amp;middot;`.
 
-For inserting the poster image, see "UEditor Image Insertion" under Edit Page Differences. On the create page TinyMCE has its own image upload but the simpler pattern is to set `innerHTML` with an `<img src="...vercel-blob...">` directly. As a fallback, the click-driven dialog flow also works: click the 图片 toolbar button → an upload dialog appears with a "+" and a hidden `<input type="file">` (index `[1]` of all file inputs on the page) → set an `id` on it, `agent-browser upload`, then click 上传 (scope by `button.el-button--success` to disambiguate from the banner upload button — see "File uploads" below).
+For inserting the poster image, **use `poster-no-qr.png`** — huodongxing auto-generates its own QR on the listing page, so the QR-stamped poster is only for WeChat/social sharing. See "UEditor Image Insertion" under Edit Page Differences. On the create page TinyMCE has its own image upload but the simpler pattern is to set `innerHTML` with an `<img src="...vercel-blob...">` directly. As a fallback, the click-driven dialog flow also works: click the 图片 toolbar button → an upload dialog appears with a "+" and a hidden `<input type="file">` (index `[1]` of all file inputs on the page) → set an `id` on it, `agent-browser upload`, then click 上传 (scope by `button.el-button--success` to disambiguate from the banner upload button — see "File uploads" below).
+
+**Gotcha:** Once inserted, the poster renders at full ~1080px width inside the editor. To reach the ticket/submission sections below, you'll need **much larger scroll distances (3000–5000px)** than usual.
 
 ### 9. Add free ticket via drawer
 


### PR DESCRIPTION
## Context

Stacked on top of #76 to address its checklist item "Skim the restructured SKILL.md to confirm nothing critical was lost in the cleanup."

Walked the original 25-quirk version against the current 7-section version. The earlier restore (#77) caught most things — banner format/size, login verify, PREFERENCES.md refs, editor detection, ref-shift warning, date-cell fallback, content checklist, dialog upload fallback, listings verify, new-tab reminder.

Two pieces from the original Quirk #6 (TinyMCE Rich Text Editor) didn't make it into the restructure and aren't in #77's restore either:

1. **Why** we use `poster-no-qr.png` for huodongxing — huodongxing auto-generates its own QR on the listing page. The file-organization comments name which poster goes where but lose the rationale, which is the easiest thing to forget when picking the wrong file.
2. **TinyMCE poster scroll-distance gotcha** — once the poster image is inserted via `innerHTML`, it renders at full ~1080px width, so you need 3000–5000px scroll distances to reach the ticket/submission sections below.

Both slotted into step 8 (Fill 活动详情) where the poster image insertion is discussed.

## Test plan

- [ ] Read the updated step 8 in `.claude/skills/huodongxing-create-event/SKILL.md` and confirm both gotchas are clear in context

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DwuKoqkVnNPNqhsEUWbJfi)_