### PR TITLE
Bump default event end time to 10:00 AM

### DIFF
--- a/.claude/skills/PREFERENCES.md
+++ b/.claude/skills/PREFERENCES.md
@@ -5,7 +5,7 @@ Current defaults for event creation. Edit these as things change.
 ## Schedule
 
 - Day: Thursday
-- Time: 8:00 - 10:30 AM
+- Time: 8:00 - 10:00 AM
 - Capacity: 25 attendees
 - Free ticket
 


### PR DESCRIPTION
## Summary
- Update `.claude/skills/PREFERENCES.md` default end time from 10:30 to 10:00, standardizing on a 2-hour AI Breakfast format.

## Context
Triggered by the #38 (May 7) agenda update. Going forward, new events will pick up 8:00 – 10:00 AM as the default unless overridden.

## Test plan
- [ ] Confirm next event creation reflects the 10:00 AM end time in posters and the huodongxing form.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DsuZjmLsPuK6Vcf5WjwiBb)_