### PR TITLE
Streamline notes template: TL;DR-only front matter, Quick Hits, persona review

### DIFF
--- a/.claude/skills/write-notes/SKILL.md
+++ b/.claude/skills/write-notes/SKILL.md
@@ -2,7 +2,7 @@
 name: write-notes
 description: Write meeting notes from an AI Breakfast transcript. Use when the user provides or references a meeting transcript and wants it turned into formatted notes following the project's guidelines.
 argument-hint: [transcript-source]
-allowed-tools: Read, Write, Edit, WebSearch, WebFetch, Bash, Glob, Grep
+allowed-tools: Read, Write, Edit, WebSearch, WebFetch, Bash, Glob, Grep, Agent
 ---
 
 You are a concise, opinionated note-writer for the AI Breakfast meetup series. Given a meeting transcript, you produce tight, readable meeting notes that highlight interesting takes and insights.
@@ -63,28 +63,74 @@ Determine the breakfast number by checking the most recent notes file in the `no
 
 ### Document Structure
 
-1. **Executive Summary** - A bullet list of topics covered. Each bullet links to its section heading followed by a dash and a 5-7 word description of the key insight. No filler framing like "This week we discussed..." — just the list. Example:
+Order: TL;DR → Tool Demo of the Week (when present) → Group Discussions → Quick Hits → Other Resources.
 
-   ```
-   - [Section title](#anchor) — 5-7 word insight description
-   ```
+1. **TL;DR** — The only front-matter section. 3 bullets max, each starting with a **bolded one-line thesis** followed by 1–2 sentences of context, ending with `See [Section title](#anchor).` Pick items that landed across multiple persona reviewers (see Persona Review below). After the bullets, add one **Also covered:** line that anchor-links the remaining sections, using `·` as separator. Group Quick Hits items in parentheses after the `#quick-hits` link. Do not add a separate Executive Summary or Summary/TOC section.
 
-2. **Group Discussions** - One subsection per major topic. Use punchy, descriptive titles. Each topic gets 2-3 short paragraphs max, proportional to discussion time. Weave in relevant member projects and work where they naturally fit the topic - don't separate member work into its own section.
+2. **Tool Demo of the Week** (when present) — Cap at three short paragraphs: what it does, what landed, what didn't, who it's for.
 
-3. **Other Resources** - Bullet list of all tools/links mentioned in the transcript. Each entry:
+3. **Group Discussions** — One subsection per major topic. Each starts with a **bolded one-line thesis** as the first sentence. 2–3 short paragraphs max. Weave in relevant member projects and work where they naturally fit the topic — don't separate member work into its own section. Avoid duplication: if the same person or pattern shows up across two sections, consolidate into one.
+
+4. **Quick Hits** — Single section for topics that landed but don't merit a full section. One short paragraph (2–4 sentences) per item, each starting with a **bolded one-line thesis**. No sub-headers.
+
+5. **Other Resources** - Bullet list of tools/links mentioned in the transcript that are **not already linked in the body prose** (no duplicates — Resources is not a recap). Each entry:
    - Has a markdown link to the specific resource (search for the real URL)
    - One punchy sentence: what it is and why it came up
    - Example: `[Prodigy](https://prodi.gy/): Annotation tool for building custom AI models with active learning. Used for domain-specific models like physio posture correction.`
 
 ### Content Organization
 
-- Section length should reflect discussion volume in the transcript.
+- Section length reflects **signal, not airtime**. Long sidetracks that didn't land for the audience compress (or move to Quick Hits) even if they ate ten minutes of the meeting.
 - Keep each section to ~3 short paragraphs max.
 - If a member's project illustrates a group discussion topic, fold it into that section rather than writing about it separately.
 
 ## After Writing
 
-Once notes are written:
+Once the draft is complete:
 
 1. Verify all links using WebFetch to confirm they resolve and match the context.
-2. Inform the user that they can run `/verify-links` for a thorough link check.
+2. Run the **Persona Review** below to identify what lands and what to cut.
+3. Run the **Editor Pass** below to apply the feedback.
+4. Inform the user that they can run `/verify-links` for a thorough link check.
+
+## Persona Review
+
+After the draft is complete, launch **three sub-agents in parallel** — each adopting a different attendee persona — to identify which parts land for a mixed audience.
+
+Use `subagent_type: general-purpose` and send all three in a single message so they run concurrently.
+
+**Personas (2 non-technical + 1 technical):**
+
+- **Non-technical persona A** — pick from: non-technical startup founder, non-technical operator, non-technical product manager. Skims past jargon; lights up at stories, demos, "aha" moments.
+- **Non-technical persona B** — pick from: marketer / content professional, designer, sales. Uses ChatGPT/Claude daily but doesn't code; cares about workflow tricks and creative tooling.
+- **Technical persona** — senior software engineer building with LLMs (Claude Code, Cursor, agent frameworks daily). Cares about architecture choices, perf numbers, gotchas; skims past beginner explanations.
+
+**Prompt template for each persona** (adapt the persona description; keep the rest):
+
+> You are roleplaying as [persona] at an AI Breakfast meetup. [2-3 sentence persona description, including what they care about and what they skip past.]
+>
+> Read the notes at: [absolute path to draft]
+>
+> Identify the parts YOU personally find interesting, surprising, or useful — things you didn't know before, would tell a friend about, or would actually try yourself.
+>
+> Output ONLY a short bulleted list (no headers, no preamble, no explanation). Each bullet should be one short sentence — what you found interesting and why it stuck with you. Aim for 5–10 bullets max. Be honest: skip anything that didn't land for you.
+
+**Reading the feedback:**
+
+- Items multiple personas flagged → strong "keep" signals; surface in TL;DR.
+- Items only the technical persona flagged → keep but tighten; consider an italic "for engineers" callout.
+- Items only one non-technical persona flagged → keep but tighten.
+- Items no one flagged → candidates to cut or compress.
+
+## Editor Pass
+
+After persona feedback is gathered, launch one **editor sub-agent** with all three persona outputs to streamline the draft.
+
+Use `subagent_type: general-purpose`. Brief it to:
+
+1. **Diagnose** what's slowing skim (3–5 bullets, citing actual section names or quotes).
+2. Confirm/adjust the structural ordering against `notes/guidelines.md`.
+3. Recommend specific **cuts/compresses** (5–10 concrete passages) with one-line rationale each.
+4. Recommend **skim aids** to add (TL;DR bullets, bolded thesis leads, italic engineer callouts).
+
+Apply the editor's recommendations to the draft. If a recommendation feels wrong, override it — the editor is advisory, not authoritative. Save the final notes to the original path.

--- a/notes/guidelines.md
+++ b/notes/guidelines.md
@@ -8,15 +8,15 @@
 
 ## Document Structure
 
-### Executive Summary
+### TL;DR
 
-- Each notes document must include an **Executive Summary** section immediately after any group photo and before the longer table of contents.
-- The Executive Summary should be a short paragraph (about 1–3 sentences) written in simple, straightforward language (around a 5th-grade reading level) with no marketing or promotional wording.
-- The first sentence should generally follow this pattern (adjusted for each event):
-  ```
-  At our <event name>, our group of <short list of attendee roles> discussed topics ranging from <topic 1 with markdown link to its section>, <topic 2 with link>, etc. The attendees also shared the latest on their work and projects, including <project 1 with link>, <project 2 with link>, etc.
-  ```
-- Always link topics and projects to their detailed sections in the same document using markdown anchor links.
+The **TL;DR** is the only front-matter section. It replaces the older Executive Summary + Summary/TOC pair — one section now does all three jobs (takeaways, scope, navigation) so the reader doesn't parse the same meeting three times before the actual notes start.
+
+- Place TL;DR immediately after the title/frontmatter (and any group photo).
+- Format: 3 bullets max. Each starts with a **bolded one-line thesis**, followed by 1–2 sentences of context, ending with `See [Section title](#anchor).` — the link points to where that takeaway lives.
+- Each bullet should be a concrete takeaway a reader can use, not a topic label. Pick the items multiple persona reviewers flagged as interesting.
+- After the bullets, add one **Also covered:** line that anchor-links the remaining sections (Tool Demo, additional Group Discussions, Quick Hits). Use `·` as a separator. Group Quick Hits items in parentheses after the `#quick-hits` link rather than linking each one individually.
+- Do **not** add a separate Executive Summary or Summary/TOC section. The TL;DR is sufficient.
 
 ### Section Headers
 
@@ -28,10 +28,17 @@
 
 - The section about member work (typically titled "Member Introductions" or similar) should focus on projects and works that members shared, not member introductions themselves. This section is about celebrating and highlighting our members' work.
 
+### Quick Hits
+
+- For topics that landed but don't merit a full section, group them under a single **Quick Hits** section with one short paragraph (2–4 sentences) per item.
+- Each Quick Hit starts with a **bolded one-line thesis**. No sub-headers inside Quick Hits — paragraphs only, so the long tail visually compresses.
+- Use Quick Hits to keep minor topics out of the main flow rather than letting every side thread become its own section.
+
 ### Other Resources Section
 
 - The last section should be titled "Other Resources".
 - Include a bullet list of all the resources mentioned in the transcripts, especially smaller tools, links, or references that were not covered in detail in the main write‑up.
+- **Do not duplicate** items already linked in the body prose. Resources is for items not previously linked — it is not a recap.
 - Do an online search to find **direct, specific links** to these resources (e.g., the actual product page, not a company homepage). If a specific link cannot be found, omit the link rather than linking to a generic page.
 - Each resource should have a concise, single-sentence description that combines:
   1. A brief description of what the resource is
@@ -54,6 +61,12 @@
 
 ## Content Organization
 
-- The volume of each section should generally reflect the volume of discussion in the transcripts. Topics or projects that were discussed more extensively should have correspondingly longer sections, while brief mentions should be shorter.
+- The volume of each section should reflect **signal, not airtime**. A long sidetrack that didn't land for the audience should be compressed (or moved to Quick Hits) even if it ate ten minutes of the meeting; a short remark that captured a real insight can earn a full paragraph.
 - Aim for no more than about three short paragraphs per major section so that each topic stays focused and easy to skim.
 - Keep the overall document to roughly a 5‑minute read. Prioritize the most important insights and examples rather than capturing every detail from the transcript.
+- Avoid duplication across sections. If two sections describe the same person, the same pattern, or the same product applied to different problems, consolidate into one place — fragmenting a strong cross-cutting insight weakens it.
+
+## Skim Aids
+
+- **Bolded thesis lead.** Start each main discussion section and each Quick Hit with a single bolded one-liner stating the takeaway. The first sentence should not bury the lead.
+- **Italic "for engineers" callouts (optional).** When a technical detail (specific framework, architecture choice, performance number) won't land for non-technical readers but is worth keeping for engineers, set it as an indented italic line so general readers can skip without losing the thread.


### PR DESCRIPTION
## Summary

Updates the notes template (`notes/guidelines.md`) and the `write-notes` skill — does **not** touch any specific notes file. Companion to PR #83 which applies these structural changes to AB#38.

### What changed

- **Single TL;DR replaces three sections.** The previous template stacked TL;DR + Executive Summary + Summary/TOC at the top, making the reader parse the same recap three times before the actual notes started. The new TL;DR carries:
  - 3 bolded-thesis bullets (concrete takeaways, not topic labels), each ending with `See [Section title](#anchor).`
  - One **Also covered:** line at the bottom that anchor-links remaining sections (Quick Hits items grouped in parens)
- **Quick Hits section** for topics that landed but don't merit a full section — paragraph-per-item, no sub-headers, each starting with a bolded thesis. Compresses the long tail visually so every minor topic doesn't look equally important.
- **"Signal not airtime"** — section length now reflects what landed for the audience, not what got the most discussion time. Long sidetracks compress.
- **Skim aids documented** — bolded thesis lead per section, optional italic "for engineers" callouts for technical asides.
- **Other Resources no-duplicate rule** — Resources is not a recap; entries that are already linked in the body prose don't belong there.
- **Persona-review + editor-pass flow baked into the skill.** After the draft, spawn 3 parallel persona reviewers (2 non-technical + 1 technical) to flag what lands; then one editor sub-agent recommends cuts/compresses. Includes prompt templates and guidance for reading the feedback.

## Test plan

- [ ] Read the updated `notes/guidelines.md` end to end; verify the TL;DR-only front matter is unambiguous
- [ ] Verify SKILL.md Document Structure ordering matches guidelines (TL;DR → Tool Demo → Group Discussions → Quick Hits → Other Resources)
- [ ] On the next transcript, run `/write-notes` and confirm the persona-review + editor-pass steps fire as documented
- [ ] Confirm the resulting notes have one front-matter section, not three


---
_Generated by [Claude Code](https://claude.ai/code/session_01HDnGua2Xdvji7dNoREa7mH)_